### PR TITLE
Remove unused local_variables call in ArgumentExtractor#extract_from_…

### DIFF
--- a/lib/observable/instrumenter.rb
+++ b/lib/observable/instrumenter.rb
@@ -347,7 +347,6 @@ module Observable
       private
 
       def extract_from_binding
-        @caller_binding.local_variables
         args = {}
 
         extract_local_variables_with_numeric_indexing(args)


### PR DESCRIPTION
…binding

The result of @caller_binding.local_variables on line 350 was never assigned or used — the same call is made immediately below in extract_local_variables_with_numeric_indexing. Removing the dead call.

https://claude.ai/code/session_01KWZUse79XR68i6nGa8VgTu