### PR TITLE
Remove dead Span#colorize_kind method

### DIFF
--- a/lib/observable/persistence/span.rb
+++ b/lib/observable/persistence/span.rb
@@ -87,19 +87,6 @@ module Observable
         end
       end
 
-      def colorize_kind(kind)
-        case kind.to_s
-        when "internal"
-          colorize(kind, GREEN)
-        when "producer"
-          colorize(kind, BLUE)
-        when "consumer"
-          colorize(kind, MAGENTA)
-        else
-          colorize(kind, WHITE)
-        end
-      end
-
       def colorize_value(value)
         case value
         when String


### PR DESCRIPTION
colorize_kind was defined but never called — not in the ai method, not anywhere else in the codebase. Removing it eliminates dead code.

https://claude.ai/code/session_01KWZUse79XR68i6nGa8VgTu