### PR TITLE
Replace bare rescue clauses with explicit StandardError

### DIFF
--- a/lib/observable/instrumenter.rb
+++ b/lib/observable/instrumenter.rb
@@ -52,7 +52,7 @@ module Observable
       return "UnknownClass" if file_name.empty?
 
       file_name.split("_").map(&:capitalize).join
-    rescue
+    rescue StandardError
       "UnknownClass"
     end
 
@@ -65,14 +65,14 @@ module Observable
           else
             caller_self.class.name
           end
-        rescue
+        rescue StandardError
           extract_namespace_from_path(@caller_binding.eval("__FILE__"))
         end
       else
         caller_location = find_caller_location
         extract_namespace_from_path(caller_location.path)
       end
-    rescue
+    rescue StandardError
       "UnknownClass"
     end
 
@@ -82,7 +82,7 @@ module Observable
       begin
         caller_self = @caller_binding.eval("self")
         caller_self.is_a?(Class)
-      rescue
+      rescue StandardError
         false
       end
     end
@@ -353,7 +353,7 @@ module Observable
         extract_local_variables_with_numeric_indexing(args)
 
         args
-      rescue
+      rescue StandardError
         {}
       end
 

--- a/lib/observable/structured_error.rb
+++ b/lib/observable/structured_error.rb
@@ -45,7 +45,7 @@ module Observable
       else
         ""
       end
-    rescue
+    rescue StandardError
       ""
     end
 
@@ -63,7 +63,7 @@ module Observable
       end
 
       error.class.name
-    rescue
+    rescue StandardError
       error.class.name
     end
 
@@ -77,7 +77,7 @@ module Observable
       else
         {}
       end
-    rescue
+    rescue StandardError
       {}
     end
 
@@ -92,7 +92,7 @@ module Observable
 
       result = begin
         converter.call(error)
-      rescue
+      rescue StandardError
         nil
       end
 


### PR DESCRIPTION
Replaces all bare `rescue` clauses with explicit `rescue StandardError` to avoid accidentally catching exceptions like `Interrupt` and `SystemExit`. Affects `instrumenter.rb` and `structured_error.rb`.