### PR TITLE
Use Span ANSI constants in SpanRepo#colorize_trace_header

### DIFF
--- a/lib/observable/persistence/span_repo.rb
+++ b/lib/observable/persistence/span_repo.rb
@@ -130,12 +130,7 @@ module Observable
       end
 
       def colorize_trace_header(trace_id)
-        # Use the same color constants from Span
-        cyan = "\e[36m"
-        bold = "\e[1m"
-        reset = "\e[0m"
-
-        "#{cyan}#{bold}#{trace_id}#{reset}"
+        "#{Span::CYAN}#{Span::BOLD}#{trace_id}#{Span::RESET}"
       end
     end
   end


### PR DESCRIPTION
Replaces locally-defined ANSI escape code variables in `SpanRepo#colorize_trace_header` with the existing constants from the `Span` class (`Span::CYAN`, `Span::BOLD`, `Span::RESET`), eliminating duplication.