### PR TITLE
Extract CallerInformation and ArgumentExtractor to module-level files

### DIFF
--- a/lib/observable/argument_extractor.rb
+++ b/lib/observable/argument_extractor.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Observable
+  class ArgumentExtractor
+    def initialize(caller_location, caller_binding = nil)
+      @caller_location = caller_location
+      @caller_binding = caller_binding
+      @method_name = caller_location.label
+    end
+
+    def extract
+      return {} unless @caller_binding
+      extract_from_binding
+    end
+
+    private
+
+    def extract_from_binding
+      args = {}
+      extract_local_variables_with_numeric_indexing(args)
+      args
+    rescue StandardError
+      {}
+    end
+
+    def extract_local_variables_with_numeric_indexing(args)
+      local_vars = @caller_binding.local_variables
+      positional_index = 0
+
+      local_vars.each do |var_name|
+        var_name_str = var_name.to_s
+
+        next if var_name_str.start_with?("_") || var_name == :instrumenter
+
+        value = @caller_binding.local_variable_get(var_name)
+
+        args[positional_index.to_s] = {
+          value: value,
+          param_name: var_name_str
+        }
+        positional_index += 1
+      end
+    end
+  end
+end

--- a/lib/observable/caller_information.rb
+++ b/lib/observable/caller_information.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Observable
+  CallerInformation = Struct.new(:method_name, :namespace, :filepath, :line_number, :arguments, :is_class_method, keyword_init: true)
+end

--- a/lib/observable/instrumenter.rb
+++ b/lib/observable/instrumenter.rb
@@ -1,5 +1,7 @@
 require "opentelemetry/sdk"
 require_relative "configuration"
+require_relative "caller_information"
+require_relative "argument_extractor"
 
 module Observable
   class Instrumenter
@@ -328,53 +330,6 @@ module Observable
 
     def extract_arguments_from_caller(caller_location)
       ArgumentExtractor.new(caller_location, @caller_binding).extract
-    end
-
-    CallerInformation = Struct.new(:method_name, :namespace, :filepath, :line_number, :arguments, :is_class_method, keyword_init: true)
-
-    class ArgumentExtractor
-      def initialize(caller_location, caller_binding = nil)
-        @caller_location = caller_location
-        @caller_binding = caller_binding
-        @method_name = caller_location.label
-      end
-
-      def extract
-        return {} unless @caller_binding
-        extract_from_binding
-      end
-
-      private
-
-      def extract_from_binding
-        @caller_binding.local_variables
-        args = {}
-
-        extract_local_variables_with_numeric_indexing(args)
-
-        args
-      rescue
-        {}
-      end
-
-      def extract_local_variables_with_numeric_indexing(args)
-        local_vars = @caller_binding.local_variables
-        positional_index = 0
-
-        local_vars.each do |var_name|
-          var_name_str = var_name.to_s
-
-          next if var_name_str.start_with?("_") || var_name == :instrumenter
-
-          value = @caller_binding.local_variable_get(var_name)
-
-          args[positional_index.to_s] = {
-            value: value,
-            param_name: var_name_str
-          }
-          positional_index += 1
-        end
-      end
     end
 
     class InstrumentationError < StandardError; end


### PR DESCRIPTION
Moves the nested `CallerInformation` struct and `ArgumentExtractor` class out of `Instrumenter` into their own files (`caller_information.rb` and `argument_extractor.rb`) to improve organisation and reduce nesting.