### PR TITLE
Introduce SerializationDepth value object to reduce primitive obsession

### DIFF
--- a/lib/observable/instrumenter.rb
+++ b/lib/observable/instrumenter.rb
@@ -1,5 +1,6 @@
 require "opentelemetry/sdk"
 require_relative "configuration"
+require_relative "serialization_depth"
 
 module Observable
   class Instrumenter
@@ -8,6 +9,7 @@ module Observable
     def initialize(tracer: nil, config: nil)
       @config = config || Configuration.config
       @tracer = tracer || OpenTelemetry.tracer_provider.tracer(@config.tracer_name)
+      @serialization_depth = SerializationDepth.new(@config.serialization_depth)
     end
 
     def instrument(caller_binding = nil, &block)
@@ -312,11 +314,7 @@ module Observable
     end
 
     def get_serialization_depth_for_class(class_name)
-      if @config.serialization_depth.is_a?(Integer)
-        return @config.serialization_depth
-      end
-
-      @config.serialization_depth[class_name] || @config.serialization_depth[:default] || @config.serialization_depth["default"] || 2
+      @serialization_depth.for_class(class_name)
     end
 
     def should_filter_pii?(param_name)

--- a/lib/observable/serialization_depth.rb
+++ b/lib/observable/serialization_depth.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Observable
+  class SerializationDepth
+    DEFAULT_DEPTH = 2
+
+    def initialize(config)
+      @config = config
+    end
+
+    def for_class(class_name)
+      if @config.is_a?(Integer)
+        @config
+      else
+        @config[class_name] || @config[:default] || @config["default"] || DEFAULT_DEPTH
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracts serialization depth configuration logic into a dedicated `SerializationDepth` class, removing the `get_serialization_depth_for_class` method from `Instrumenter` and replacing primitive type-checking with a proper value object.